### PR TITLE
Change reference in home page to lead to getting started notebook

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -51,7 +51,7 @@
         without writing a single line of code.
       </p>
       <a
-        href="/tutorials/klusterai-api/multiple-tasks-batch-api/"
+        href="/tutorials/klusterai-api/getting-started/"
         target="\_blank"
         class="btn"
         >Check Notebook


### PR DESCRIPTION
I have added the getting-started notebook to the docs. This changes the link to that notebook on the homepage.

For this change to take effect, [this PR](https://github.com/kluster-ai/docs/pull/16) must be approved first. That PR includes the mentioned notebook in the docs repo.