### PR TITLE
Change everything to sentence case

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -31,19 +31,19 @@
   </div>
   <div class="featured-content">
     <div class="feature">
-      <h2>Early-Access Program</h2>
-      <img src="./assets/images/circle1.webp" alt="Early-Access Program" />
+      <h2>Early-access program</h2>
+      <img src="./assets/images/circle1.webp" alt="Early-access program" />
       <p>Find out more about the benefits and features of the program.</p>
       <a href="https://kluster.ai/early-access/" target="\_blank" class="btn"
-        >Learn More
+        >Learn more
         <span class="md-icon"
           >{% include ".icons/material/arrow-right.svg" %}</span
         ></a
       >
     </div>
     <div class="feature">
-      <h2>Get Coding</h2>
-      <img src="./assets/images/circle2.webp" alt="Colab Notebook" />
+      <h2>Get coding</h2>
+      <img src="./assets/images/circle2.webp" alt="Colab notebook" />
       <p>
         Test-drive
         <a href="https://kluster.ai" target="\_blank">kluster.ai</a>
@@ -54,7 +54,7 @@
         href="/tutorials/klusterai-api/getting-started/"
         target="\_blank"
         class="btn"
-        >Check Notebook
+        >Check notebook
         <span class="md-icon"
           >{% include ".icons/material/arrow-right.svg" %}</span
         ></a


### PR DESCRIPTION
As decided by the kluster.ai marketing team, we need to migrate to sentence case instead of title case.
Ref: https://papermoon-io.slack.com/archives/C07K31UG87Q/p1733322925986339 