### PR TITLE
Remove early access from home page

### DIFF
--- a/material-overrides/assets/stylesheets/home.css
+++ b/material-overrides/assets/stylesheets/home.css
@@ -62,7 +62,7 @@
   text-align: center;
   padding: 0.5rem;
   color: var(--md-default-fg-color);
-  width: 30%;
+  width: 35%;
   max-width: 60vw;
   border: 1.5px solid var(--md-primary-fg-color);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="featured-content">
-    <div class="feature" style="width: 35%; margin-right: -2%;"> 
+    <div class="feature">
       <h2>Get coding</h2>
       <img src="./assets/images/circle2.webp" alt="Colab notebook" />
       <p>
@@ -49,7 +49,7 @@
         ></a
       >
     </div>
-    <div class="feature" style="width: 35%;">
+    <div class="feature">
       <h2>Questions?</h2>
       <img src="./assets/images/circle3.webp" alt="FAQs" />
       <p>


### PR DESCRIPTION
Early access has been removed and will no longer be used. I extracted that from the homepage and reordered the remaining sections.