### PR TITLE
Changed FAQ link to new kluster's website

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -56,7 +56,7 @@
         Get answers to common questions about
         <a href="https://kluster.ai">kluster.ai</a> capabilities and setup.
       </p>
-      <a href="https://kluster.ai/faq/" target="\_blank" class="btn"
+      <a href="https://www.kluster.ai/adaptive-inference" target="\_blank" class="btn"
         >FAQs
         <span class="md-icon"
           >{% include ".icons/material/arrow-right.svg" %}</span


### PR DESCRIPTION
In the new website the FAQ is no longer in the same direction. 