### PR TITLE
add template for the API page

### DIFF
--- a/material-overrides/api.html
+++ b/material-overrides/api.html
@@ -2,7 +2,22 @@
 
 {% block site_nav %}
 {% if nav %}
-  <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="toc">
+  {% if page.meta and page.meta.hide %}
+    {% set hidden = "hidden" if "navigation" in page.meta.hide %}
+  {% endif %}
+  <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" {{ hidden }}>
+    <div class="md-sidebar__scrollwrap">
+      <div class="md-sidebar__inner">
+        {% include "partials/nav.html" %}
+      </div>
+    </div>
+  </div>
+{% endif %}
+{% if "toc.integrate" not in features %}
+  {% if page.meta and page.meta.hide %}
+    {% set hidden = "hidden" if "toc" in page.meta.hide %}
+  {% endif %}
+  <div class="md-sidebar md-sidebar--secondary left" data-md-component="sidebar" data-md-type="toc" {{ hidden }}>
     <div class="md-sidebar__scrollwrap">
       <div class="md-sidebar__inner">
         {% set title = lang.t("toc") %}

--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -756,3 +756,11 @@ details.child {
 .md-banner__inner p {
   margin: .5em;
 }
+
+/** API Template Styling */
+/* Move TOC to the left */
+@media screen and (min-width: 60em) {
+  .md-sidebar--secondary.left {
+    order: 0;
+  }
+}


### PR DESCRIPTION
This PR switches the TOC to the left for the API page and sets the header to API endpoints using a template