### PR TITLE
add badges for where to go next cards

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -764,3 +764,31 @@ details.child {
     order: 0;
   }
 }
+
+/** Where to Go Next Badge styling */
+.md-typeset span.badge {
+  border-radius: var(--md-border-radius);
+  font-size: 0.8em;
+  padding: 0.2em 0.5em;
+  margin-right: 0.5em;
+}
+
+.md-typeset span.badge.tutorial {
+  background-color: var(--blue-violet);
+  color: var(--light);
+}
+
+.md-typeset span.badge.guide {
+  background-color: var(--electric-indigo);
+  color: var(--light);
+}
+
+.md-typeset span.badge.learn {
+  background-color: var(--vibrant-coral);
+  color: var(--light);
+}
+
+.md-typeset span.badge.external {
+  background-color: var(--mint);
+  color: var(--dark);
+}


### PR DESCRIPTION
This PR adds badges. This image is maybe a little bit confusing cause I left the text for all of them as "Guide" (but that's controlled in the kluster-docs repo anyways). So this is just so you can see the colors of each badge type

<img width="1128" alt="Screenshot 2025-02-21 at 12 33 32 PM" src="https://github.com/user-attachments/assets/8f628300-0193-426c-981d-155b153efc96" />
