### PR TITLE
put a border around images

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -801,3 +801,9 @@ details.child {
   background-color: var(--mint);
   color: var(--dark);
 }
+
+/* Image styling */
+.md-typeset img {
+  border: 1px solid var(--platinum);
+  border-radius: var(--md-border-radius);
+}


### PR DESCRIPTION
There were some images that had a white background on the docs site white background, so I thought it might be nice to wrap a border around the image just to provide a clean outline

Before: 
<img width="1148" alt="Screenshot 2025-02-24 at 5 53 03 PM" src="https://github.com/user-attachments/assets/0078b48b-e4b7-48e6-ba76-130259433278" />

After:
<img width="1141" alt="Screenshot 2025-02-24 at 5 53 23 PM" src="https://github.com/user-attachments/assets/aafca764-836f-4617-b8d9-adc3a5adefc5" />
