### PR TITLE
Update link to notebooks

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -59,7 +59,7 @@
         without writing a single line of code.
       </p>
       <a
-        href="/tutorials/klusterai-api/text-classification-api/"
+        href="/tutorials/klusterai-api/text-classification/text-classification-openai-api/"
         class="btn"
         >Check notebooks
         <span class="md-icon">{% include ".icons/material/arrow-right.svg" %}</span>


### PR DESCRIPTION
The home page link was pointing to the first tutorial, so this just updates that to point to the new location of it