### PR TITLE
update site name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Documentation for kluster.ai
+site_name: kluster.ai Docs
 site_url: https://docs.kluster.ai/
 home_url: https://kluster.ai/
 home_name: kluster.ai


### PR DESCRIPTION
Update the site name. This gets appended to the end of each of the meta titles, for example: `Integrate with LangChain | kluster.ai Docs`. This just shortens it up a little bit so it doesn't take up too much space in the meta title