### PR TITLE
Change Font for API Matic

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -768,6 +768,14 @@ details.child {
 
 /** API Template Styling */
 /* Move TOC to the left */
+#apimatic-widget * {
+  font-family: 'Space Grotesk', sans-serif;
+}
+
+#apimatic-widget pre {
+  font-family: 'Courier Prime', 'Courier New', monospace;
+}
+
 @media screen and (min-width: 60em) {
   .md-sidebar--secondary.left {
     order: 0;


### PR DESCRIPTION
This PR implements CCS styling for the content page API Matic, updating the fonts to 'Space Grotesk' and leaving the snippets in another font. 
