### PR TITLE
Remove Badges

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -776,6 +776,10 @@ details.child {
   font-family: 'Courier Prime', 'Courier New', monospace;
 }
 
+.app-layout-language-selector {
+  display: none;
+}
+
 @media screen and (min-width: 60em) {
   .md-sidebar--secondary.left {
     order: 0;

--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -768,6 +768,14 @@ details.child {
 
 /** API Template Styling */
 /* Move TOC to the left */
+#apimatic-widget * {
+  font-family: 'Space Grotesk', sans-serif;
+}
+
+#apimatic-widget pre {
+  font-family: 'Courier Prime', 'Courier New', monospace;
+}
+
 @media screen and (min-width: 60em) {
   .md-sidebar--secondary.left {
     order: 0;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,8 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - toc.follow
+extra_javascript:
+  - js/remove-badges.js    
 extra_css:
   - assets/stylesheets/terminal.css
   - assets/stylesheets/timeline-neoteroi.css


### PR DESCRIPTION
This PR adds a small CSS rule to hide the APIMatic language selector badges (HTTP, Python) by default across the portal pages and includes the route for the script in the YML file to function.

This PR needs to be merged with this one:

