### PR TITLE
add script to set height of the APImatic widget

### DIFF
--- a/material-overrides/portal.html
+++ b/material-overrides/portal.html
@@ -165,6 +165,27 @@
     };
     document.getElementsByTagName("head")[0].appendChild(script);
     </script>
+
+  <script>
+    function adjustWidgetHeight() {
+      const mdMain = document.querySelector('.md-main');
+      const apimaticWidget = document.getElementById('apimatic-widget');
+      const mdFooterMetaInner = document.querySelector('.md-footer-meta__inner');
+  
+      if (!mdMain || !apimaticWidget) return;
+  
+      const mdMainHeight = mdMain.offsetHeight;
+      const mdFooterMetaInnerHeight = mdFooterMetaInner?.offsetHeight || 0;
+      const height = mdMainHeight - mdFooterMetaInnerHeight;
+  
+      // test using dev tools should it display the height in real time as it changes
+      apimaticWidget.style.height = `${height}px`;
+      console.log('[apimatic] Height adjusted to:', height);
+    }
+  
+    document.addEventListener('DOMContentLoaded', adjustWidgetHeight);
+    window.addEventListener('resize', adjustWidgetHeight);
+  </script>
 {% endblock %}
 
 {% block container %}


### PR DESCRIPTION
In this PR, I added a script to automatically set the height of `#apimatic-widget` for different screen sizes, based on the feedback received.

What the original script does:

- It calculates the height of `.md-main` and subtracts the footer's height.
- It applies the result to `#apimatic-widget` using `offsetHeight`.

I added:

- Made adjustWidgetHeight() reusable so it runs on both load and resize for real-time height adjustment.
- Added a resize event listener so the widget height updates when the window size changes in real time.
- A `console.log` for visual confirmation 
