### PR TITLE
Add New Banner

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -30,7 +30,7 @@
 
 {% block announce %}
   <p>
-    Inference, Fine-Tuning, and Dedicated Deployments services have been sunset as we focus on Guardrails for AI. <a href="https://kluster.ai/blog/end-of-life-for-inference-fine-tuning-and-dedicated-deployments" target="_blank" rel="noopener">Find out more</a>.
+    Inference, Fine-Tuning & Dedicated Deployments were sunset on July 24 at 11PM ET. <a href="https://kluster.ai/blog/end-of-life-for-inference-fine-tuning-and-dedicated-deployments" target="_blank" rel="noopener">Learn more</a>.
   </p>
 {% endblock %}
 

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -30,7 +30,7 @@
 
 {% block announce %}
   <p>
-    We will be <a href="https://kluster.ai/blog/end-of-life-for-inference-fine-tuning-and-dedicated-deployments" target="_blank" rel="noopener">sunsetting Inference, Fine-Tuning, and Dedicated Deployments</a> on July 24 at 11pm ET.
+    Inference, Fine-Tuning, and Dedicated Deployments services have been sunset as we focus on Guardrails for AI. <a href="https://kluster.ai/blog/end-of-life-for-inference-fine-tuning-and-dedicated-deployments" target="_blank" rel="noopener">Find out more</a>.
   </p>
 {% endblock %}
 


### PR DESCRIPTION
This pull request updates the announcement in the `material-overrides/main.html` file to reflect the completion of the sunsetting process for certain services.

* **Announcement update**:
  * Updated the announcement text to indicate that Inference, Fine-Tuning, and Dedicated Deployments services have been sunset, with a focus shift to Guardrails for AI. The link to the blog post remains unchanged. (`[material-overrides/main.htmlL33-R33](diffhunk://#diff-1632ed8257a41f38dd75eb254f77b26ee13443ae895b24aa4305201d38d6b6e6L33-R33)`)