### PR TITLE
Update Route for Verify Card

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -45,7 +45,7 @@
       <h2>Verify Reliability</h2>
       <div class="feature-divider"></div>
       <p>Use kluster.ai's Verify service to validate the reliability and accuracy of LLM outputs.</p>
-      <a href="/tutorials/klusterai-api/reliability/" class="card-button">Explore Verify</a>
+      <a href="/verify/overview/" class="card-button">Explore Verify</a>
     </div>
 
     <div class="feature-card">


### PR DESCRIPTION
This pull request updates a hyperlink in the `material-overrides/home.html` file to point to a new URL for the "Explore Verify" button.

* Updated the `href` attribute of the "Explore Verify" button to `/verify/overview/` from `/tutorials/klusterai-api/reliability/` to reflect the updated location of the Verify service overview. (`[material-overrides/home.htmlL48-R48](diffhunk://#diff-8022bfde129910441b6eefb8239ae5cf93361d79cb643248f3f5b99506709999L48-R48)`)