### PR TITLE
Get API Key Redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -30,7 +30,7 @@
     },
     {
       "key": "/get-started/get-api-key/",
-      "value": "/verify/get-api-key/"
+      "value": "/get-api-key/"
     },
     {
       "key": "/get-started/integrations/",
@@ -114,7 +114,7 @@
     },
     {
       "key": "/get-started/start-api/",
-      "value": "/verify/get-api-key/"
+      "value": "/get-api-key/"
     },
     {
       "key": "/get-started/start-building/",


### PR DESCRIPTION
This pull request updates the `redirects.json` file to correct the destination paths for several redirects. The changes ensure that the URLs point to the appropriate locations.

* [`redirects.json`](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L33-R33): Updated the redirect for `/get-started/get-api-key/` to point to `/get-api-key/` instead of `/verify/get-api-key/`.
* [`redirects.json`](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L117-R117): Updated the redirect for `/get-started/start-api/` to point to `/get-api-key/` instead of `/verify/get-api-key/`.