### PR TITLE
Center screenshots

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -1081,10 +1081,13 @@ li.rc-menu-item-group:has(> div[title="Models"]) {
 }
 
 /* Image styling */
-.md-typeset p > img {
+.md-typeset p > img,
+.md-typeset p > a.glightbox > img {
   border: var(--img-border);
   border-radius: 0.5rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  display:block;
+  margin: 1em auto;
 }
 
 /* Where to go next cards styling */

--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -1081,8 +1081,7 @@ li.rc-menu-item-group:has(> div[title="Models"]) {
 }
 
 /* Image styling */
-.md-typeset p > img,
-.md-typeset p > a.glightbox > img {
+.md-typeset img {
   border: var(--img-border);
   border-radius: 0.5rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);

--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -1086,7 +1086,7 @@ li.rc-menu-item-group:has(> div[title="Models"]) {
   border: var(--img-border);
   border-radius: 0.5rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  display:block;
+  display: block;
   margin: 1em auto;
 }
 


### PR DESCRIPTION
Using Glightbox changes the class for the screenshots and we lose all our styling. This PR fixes that issue and centers it.

<img width="754" height="775" alt="image" src="https://github.com/user-attachments/assets/12766a1f-0982-4ebe-925e-939b9595894f" />
