### PR TITLE
Home button border fix

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -1273,7 +1273,7 @@ span.badge.integration {
 }
 
 /* Image styling */
-.md-typeset img {
+.md-typeset p > a.glightbox > img {
   border: var(--img-border);
   border-radius: 0.5rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
This PR fixes the issue with the border on one of the home buttons.
<img width="910" height="302" alt="image" src="https://github.com/user-attachments/assets/ac0c6ed8-8616-4ff5-9155-100e2cd7c7f8" />

It should be like this:

<img width="910" height="302" alt="image" src="https://github.com/user-attachments/assets/b30d1181-4e98-412a-bd5e-6de79fc11b49" />
