### PR TITLE
update the interface styles

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -848,14 +848,14 @@ details.interface > summary::before {
 }
 
 .md-typeset details.interface {
-  border: 1px solid var(--light-green-30);
+  border: 1px solid var(--border-color);
   box-shadow: none;
   width: auto;
 }
 
 [dir='ltr'] .md-typeset details.interface > summary {
   padding: 1em 0 1em 1em;
-  background-color: var(--dark);
+  background-color: var(--border-color);
 }
 
 .md-typeset details.interface > summary:after {
@@ -869,7 +869,7 @@ details.interface > summary::before {
 }
 
 .md-typeset details.interface hr {
-  border-bottom: 1px solid var(--light-green-30);
+  border-bottom: 1px solid var(--border-color);
 }
 
 /* Child adomonition styling */


### PR DESCRIPTION
This pull request updates the styling for interface admonitions.

I swapped the colors from the light mode fix branch to be this blueish greenish color that we use so it blends a little bit more.  I felt like the black for dark mode was too stark of a contrast compared to the content inside the tabs. I also felt like the grey for the light mode didn't blend well with the surrounding blueish greenish colors 🤷‍♀️ 

<img width="954" height="538" alt="Screenshot 2025-08-28 at 2 45 00 PM" src="https://github.com/user-attachments/assets/0a5a8b8d-7725-48ca-839a-e743d8a558ca" />
<img width="977" height="522" alt="Screenshot 2025-08-28 at 2 45 16 PM" src="https://github.com/user-attachments/assets/974abc1b-0ef3-47b4-a491-8290ec7bd3cb" />
