### PR TITLE
update mkdocs with toc script 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: kluster.ai Docs
 site_url: https://docs.kluster.ai/
 home_url: https://www.kluster.ai/
 home_name: kluster.ai
-site_dir: /var/www/kluster-docs-static
+site_dir: site #/var/www/kluster-docs-static
 docs_dir: kluster-docs
 copyright: © 2025 kluster.ai. All rights reserved.
 theme:
@@ -41,6 +41,7 @@ extra_css:
   - assets/stylesheets/timeline-neoteroi.css
 extra_javascript:
   - js/clipboardCopy.js
+  - js/fix-toc-scroll.js
 markdown_extensions:
   - admonition
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: kluster.ai Docs
 site_url: https://docs.kluster.ai/
 home_url: https://www.kluster.ai/
 home_name: kluster.ai
-site_dir: site #/var/www/kluster-docs-static
+site_dir: /var/www/kluster-docs-static
 docs_dir: kluster-docs
 copyright: © 2025 kluster.ai. All rights reserved.
 theme:
@@ -41,7 +41,7 @@ extra_css:
   - assets/stylesheets/timeline-neoteroi.css
 extra_javascript:
   - js/clipboardCopy.js
-  - js/fix-toc-scroll.js
+  - js/fixToc.js
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
Updates the mkdocs file to use the toc scroll script.

Related to [kluster docs #187](https://github.com/kluster-ai/docs/pull/187)