### PR TITLE
Add Visual Studio install tile to homepage IDE grid

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -41,6 +41,10 @@
             <span class="ide-icon">{% include ".icons/simple/jetbrains.svg" %}</span>
             JetBrains
           </a>
+          <a href="/code-reviews/get-started/installation/#__tabbed_1_4" class="ide-btn md-button">
+            <span class="ide-icon">{% include ".icons/material/microsoft-visual-studio.svg" %}</span>
+            Visual Studio
+          </a>
         </div>
       </div>
       <div class="install-column install-box">


### PR DESCRIPTION
Adds a Visual Studio button after JetBrains in the IDE extensions grid on the homepage. Links to the new Visual Studio tab in the installation guide via the #__tabbed_1_4 anchor.