### PR TITLE
Wire up top-level changelog with divider and redirect

### DIFF
--- a/material-overrides/assets/stylesheets/nav.css
+++ b/material-overrides/assets/stylesheets/nav.css
@@ -1,0 +1,17 @@
+/* --- Changelog nav divider: subtle separator above the last primary-nav item ---
+   Position-based selector. Changelog is currently the last top-level entry
+   in the primary nav. If the nav order changes, this rule must be updated.
+   This avoids brittle href matching, which fails on the home page where the
+   link is rendered as a relative path (`href="changelogs/"`, no leading slash)
+   while deep content pages render it with leading slashes that satisfy
+   `[href$="/changelogs/"]`.
+--- */
+.md-nav--primary > .md-nav__list > .md-nav__item:last-child {
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+[data-md-color-scheme="slate"] .md-nav--primary > .md-nav__list > .md-nav__item:last-child {
+  border-top-color: rgba(255, 255, 255, 0.15);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,9 +38,10 @@ theme:
         icon: material/weather-night
         name: Switch to dark mode
 extra_css:
+  - assets/stylesheets/ai-file-actions.css
+  - assets/stylesheets/nav.css
   - assets/stylesheets/terminal.css
   - assets/stylesheets/timeline-neoteroi.css
-  - assets/stylesheets/ai-file-actions.css
 extra_javascript:
   - js/ai-file-actions.js
 hooks:
@@ -82,9 +83,10 @@ plugins:
       js_files:
         - js/ai-file-actions.js
       css_files:
+        - assets/stylesheets/ai-file-actions.css
+        - assets/stylesheets/nav.css
         - assets/stylesheets/terminal.css
         - assets/stylesheets/timeline-neoteroi.css
-        - assets/stylesheets/ai-file-actions.css
       scoped_css_templates:
         home.html:
           - assets/stylesheets/home.css

--- a/redirects.json
+++ b/redirects.json
@@ -45,6 +45,10 @@
       "value": "/code-reviews/ide-reviews/ai-generated-code/examples/vscode-admin-endpoint/"
     },
     {
+      "key": "/code-reviews/changelogs/",
+      "value": "/changelogs/"
+    },
+    {
       "key": "/code-reviews/agent-mode/manual-agent-reviews/",
       "value": "/code-reviews/ide-reviews/ai-generated-code/on-demand-reviews/"
     },


### PR DESCRIPTION
Add nav.css with a subtle position-based divider above the last primary-nav entry (currently Changelog), registered in extra_css and the minify plugin's css_files so it loads on every template including home.html. Add a redirect from /code-reviews/changelogs/ to /changelogs/ so existing bookmarks keep working after the page move in the docs repo.