### PR TITLE
Header button styling

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -503,7 +503,8 @@ input.md-search__input[placeholder="Search"]::placeholder {
   [data-md-toggle="search"]:checked ~ .md-header .md-search__form {
     background-color: var(--search-input-bg-color);
   }
-
+  
+  /* Keep compact utility controls visible when desktop search expands. */
   [data-md-toggle="search"]:checked ~ .md-header .md-header__option {
     max-width: 100%;
     opacity: 1;

--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -504,7 +504,6 @@ input.md-search__input[placeholder="Search"]::placeholder {
     background-color: var(--search-input-bg-color);
   }
 
-  /* Keep compact utility controls visible under the search overlay. */
   [data-md-toggle="search"]:checked ~ .md-header .md-header__option {
     max-width: 100%;
     opacity: 1;

--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -504,10 +504,18 @@ input.md-search__input[placeholder="Search"]::placeholder {
     background-color: var(--search-input-bg-color);
   }
 
-  /* Keep compact utility controls visible when desktop search expands. */
+  /* Keep compact utility controls visible under the search overlay. */
   [data-md-toggle="search"]:checked ~ .md-header .md-header__option {
     max-width: 100%;
     opacity: 1;
+  }
+
+  [data-md-toggle="search"]:checked ~ .md-header .md-header__video-library,
+  [data-md-toggle="search"]:checked
+    ~ .md-header
+    .md-header__option[data-md-component="palette"]
+    .md-header__button {
+    z-index: 0;
   }
 }
 


### PR DESCRIPTION
This pull request updates the search overlay behavior in the Kluster Material theme CSS to improve the visibility and stacking order of utility controls when the desktop search is expanded.

Search overlay and utility controls:

* Added a CSS rule to set `z-index: 0` for `.md-header__video-library` and the palette button when search is active, ensuring these elements appear under the search overlay and do not interfere visually.

<img width="1005" height="107" alt="image" src="https://github.com/user-attachments/assets/95e2969f-faf7-4d23-a066-d1fe3670c60a" />
