### PR TITLE
Remove header logo hover

### DIFF
--- a/material-overrides/assets/stylesheets/kluster.css
+++ b/material-overrides/assets/stylesheets/kluster.css
@@ -349,6 +349,10 @@
   height: 28px;
 }
 
+.md-header__button.md-logo:hover {
+  background: transparent;
+}
+
 .md-header__buttons {
   display: flex;
   gap: 1em;


### PR DESCRIPTION
This PR removes the hover effect on the logo in the header.
<img width="206" height="76" alt="image" src="https://github.com/user-attachments/assets/ccd9d77b-9ff3-4e75-9f3d-0d398daf25ed" />
