### PR TITLE
Fix Antigravity IDE install deep link on homepage

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -33,7 +33,7 @@
             <span class="ide-icon">{% include ".icons/simple/windsurf.svg" %}</span>
             Windsurf
           </a>
-          <a href="antigravity:extension/klusterai.kluster-verify-code" target="_blank" rel="noopener noreferrer" class="ide-btn md-button">
+          <a href="antigravity-ide:extension/klusterai.kluster-verify-code" target="_blank" rel="noopener noreferrer" class="ide-btn md-button">
             <span class="ide-icon">{% include ".icons/antigravity/antigravity.svg" %}</span>
             Antigravity
           </a>


### PR DESCRIPTION
Antigravity renamed its app to "Antigravity IDE" and now registers the `antigravity-ide` URL protocol (per product.json urlProtocol). Update the homepage install button scheme from `antigravity:` to `antigravity-ide:` so the one-click extension install opens the IDE instead of resolving to the wrong target.